### PR TITLE
CMakeLists supporting dynamic libraries for different operating systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 # problem-generator/CMakeLists.txt
 
+# Older versions may still work but were not tested.
+cmake_minimum_required(VERSION 3.18)
+
+project(problem_generator)
+
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CARGO_CMD cargo build)
     set(TARGET_DIR "debug")
@@ -7,8 +12,20 @@ else ()
     set(CARGO_CMD cargo build --release)
     set(TARGET_DIR "release")
 endif ()
+if(WIN32 OR MSYS OR CYGWIN OR MINGW)
+set(PROBLEM_GENERATOR_SO "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/libproblem_generator.dll")
+endif()
 
-set(PROBLEM_GENERATOR_SO "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/libproblem_generator.so")
+
+
+if(UNIX)
+    if(APPLE)
+        set(PROBLEM_GENERATOR_SO "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/libproblem_generator.dylib")
+    else()
+        set(PROBLEM_GENERATOR_SO "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/libproblem_generator.so")
+    endif()
+endif()
+
 
 add_custom_target(problem_generator ALL
     COMMENT "Compiling problem generator module"


### PR DESCRIPTION
- Minors, adding project name and requirement of cmake version.
- Update the CMakeLists.txt file, following the naming rule of libraries on different operating systems.